### PR TITLE
Fixes #69

### DIFF
--- a/src/freeplaneGTD.addon.mm
+++ b/src/freeplaneGTD.addon.mm
@@ -64,7 +64,7 @@
 <attribute NAME="freeplaneVersionTo" VALUE=""/>
 <attribute NAME="downloadUrl" VALUE="http://www.itworks.hu/freeplanegtd-release/" OBJECT="java.net.URI|http://www.itworks.hu/freeplanegtd-release/"/>
 <attribute NAME="changelogUrl" VALUE=""/>
-<attribute NAME="updateUrl" VALUE="http://www.itworks.hu/freeplanegtd-release/version.properties" OBJECT="java.net.URI|http://www.itworks.hu/freeplanegtd-release/version.properties"/>
+<attribute NAME="updateUrl" VALUE="http://www.itworks.hu/freeplanegtd-release/version.properties" OBJECT="java.net.URL|http://www.itworks.hu/freeplanegtd-release/version.properties"/>
 <richcontent TYPE="NOTE">
 
 <html>


### PR DESCRIPTION
Old-time issue, where Freeplane 1.3 relies on the java.net.URL object instead of java.net.URI type for updateURL. 
The map converts to URI by default. This is a backwards compatibility fix for FP 1.3 users only.