### PR TITLE
fix for compatibility with Groovy 2.5.x

### DIFF
--- a/src/resources/zips/lib/freeplaneGTD/Tag.groovy
+++ b/src/resources/zips/lib/freeplaneGTD/Tag.groovy
@@ -53,7 +53,7 @@ class Tag {
 
     Tag addContent(Object content, Map params = null) {
         // Very simple sanitation for HTML entities <> here!
-        this.content.push(content.toString().replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;'))
+        this.content.add(content.toString().replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;'))
         if (params) {
             this.params = params
         }
@@ -61,24 +61,24 @@ class Tag {
     }
 
     Tag addPreformatted(String tag) {
-        this.content.push(tag)
+        this.content.add(tag)
         return this
     }
 
     Tag addContent(Tag tag) {
-        this.content.push(tag)
+        this.content.add(tag)
         return this
     }
 
     Tag addContent(tagName, Object content, Map params = null) {
         Tag tag = new Tag(tagName, content, params)
-        this.content.push(tag)
+        this.content.add(tag)
         return this
     }
 
     Tag addChild(tagName, Map params = null) {
         Tag tag = new Tag(tagName, params)
-        this.content.push(tag)
+        this.content.add(tag)
         return tag
     }
 


### PR DESCRIPTION
org.codehaus.groovy.runtime.DefaultGroovyMethods has changed behavior of method `push` since Groovy 2.5:    
~~~
* Note: The behavior of this method changed in Groovy 2.5 to align with Java.
* If you need the old behavior use 'add'.
~~~

Freeplane 1.7.x uses Groovy 2.5 and it leads to problem described in https://sourceforge.net/p/freeplane/bugs/2613/

It can be fixed as follows.